### PR TITLE
Switch from SweetAlert to SweetAlert2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "primer-blankslate": "^1.3.0",
     "primer-states": "^0.4.4",
     "primer-tooltips": "^1.3.0",
-    "sweetalert": "^1.1.3"
+    "sweetalert2": "^7.0.9"
   }
 }

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -7,7 +7,7 @@
 
 require('./bootstrap');
 
-require('sweetalert');
+require('sweetalert2');
 
 require('primer-alerts');
 require('primer-avatars');

--- a/resources/assets/js/landing.js
+++ b/resources/assets/js/landing.js
@@ -1,1 +1,1 @@
-require('sweetalert');
+require('sweetalert2');

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -1,7 +1,6 @@
 @import "~bootswatch/flatly/variables";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap";
 @import "~bootswatch/flatly/bootswatch";
-@import "~sweetalert/dist/sweetalert.css";
 @import "~bootstrap-social/bootstrap-social";
 @import "~primer-alerts/build/build.css";
 @import "~primer-avatars/build/build.css";

--- a/resources/assets/sass/join.scss
+++ b/resources/assets/sass/join.scss
@@ -2,7 +2,6 @@
 @import url("https://fonts.googleapis.com/css?family=Raleway:300,400,600");
 
 // Variables
-@import "~sweetalert/dist/sweetalert.css";
 @import "join/styles";
 @import "~bootswatch/flatly/variables";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap";

--- a/resources/assets/sass/landing.scss
+++ b/resources/assets/sass/landing.scss
@@ -2,6 +2,5 @@
 @import url("https://fonts.googleapis.com/css?family=Raleway:300,400,600");
 
 // Variables
-@import "~sweetalert/dist/sweetalert.css";
 @import "landing/variables";
 @import "landing/styles";

--- a/resources/views/join.blade.php
+++ b/resources/views/join.blade.php
@@ -66,7 +66,7 @@
     <script src="https://unpkg.com/sweetalert2@7.0.6/dist/sweetalert2.all.js"></script>
     @if (count($errors) > 0)
         <script>
-            sweetAlert("Oops...", "{{ $errors->first() }}", "error");
+            swal("Oops...", "{{ $errors->first() }}", "error");
         </script>
     @endif
     @if (session('success'))

--- a/resources/views/landing.blade.php
+++ b/resources/views/landing.blade.php
@@ -75,7 +75,7 @@
     @include('layouts.code.footer')
     @if (count($errors) > 0)
     <script>
-        sweetAlert("Oops...", "{{ $errors->first() }}", "error");
+        swal("Oops...", "{{ $errors->first() }}", "error");
     </script>
 @endif
 @if (session('success'))

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -88,7 +88,7 @@
 <!-- Scripts -->
 @if (count($errors) > 0)
     <script>
-        sweetAlert("Oops...", "{{ $errors->first() }}", "error");
+        swal("Oops...", "{{ $errors->first() }}", "error");
     </script>
 @endif
 @if (session('success'))

--- a/yarn.lock
+++ b/yarn.lock
@@ -6408,9 +6408,9 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-sweetalert@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/sweetalert/-/sweetalert-1.1.3.tgz#d2c31ea492b22b6a8d887aea15989a238fc084ae"
+sweetalert2@^7.0.9:
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-7.0.9.tgz#04ec97379d7d5c6d210b27f25453d650e5492b27"
 
 synesthesia@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
I would like to propose to switch from SweetAlert to [SweetAlert2](https://github.com/limonte/sweetalert2) - the supported fork of SweetAlert. The original reason for creating SweetAlert2 is the inactivity of SweetAlert: https://stackoverflow.com/a/27842854/1331425 

### Reasons to switch:

1. Accessibility (WAI-ARIA) - SweetAlert2 is fully WAI-ARIA compatible and supports all popular screen-readers. Accessibility is a must in 2017, there are a lot of explanatory and tech articles, but this one is truly inspirable: [Software development 450 words per minute](https://www.vincit.fi/en/blog/software-development-450-words-per-minute/)

2. Better buttons contrast is a huge advantage for all users especially for users with vision disabilities. 

3. You actually already using it in https://github.com/orgmanager/orgmanager/blob/master/resources/views/join.blade.php#L66 

3. Better support, average time to resolve an issue:

   - SweetAlert: ![](http://isitmaintained.com/badge/resolution/t4t5/sweetalert.svg)
   - SweetAlert2: ![](http://isitmaintained.com/badge/resolution/limonte/sweetalert2.svg)

4. SweetAlert2 is more popular that SweetAlert:

   - SweetAlert: ![](https://img.shields.io/npm/dm/sweetalert.svg)
   - SweetAlert2: ![](https://img.shields.io/npm/dm/sweetalert2.svg)
