### PR TITLE
Added rel="noopener noreferrer"

### DIFF
--- a/resources/views/empty.blade.php
+++ b/resources/views/empty.blade.php
@@ -10,7 +10,7 @@
         <div class="mt-15">
             <p class="text-black-light text-2xl m-4 text-center">Looks like there's nothing here</p>
             <p class="text-base text-black-darker mb-2 text-center">Try to  sync the from your Github account, using the sync button below.</p>
-            <p class="text-base text-black-darker text-center">If your  organizations aren't showing here after sync, check <a class="no-underline text-inherit link-shadow link-transition" href="https://github.com/settings/connections/applications/{{ config('services.github.client_id') }}" target="_blank">we’ve been given access to them</a>.</p>
+            <p class="text-base text-black-darker text-center">If your  organizations aren't showing here after sync, check <a class="no-underline text-inherit link-shadow link-transition" href="https://github.com/settings/connections/applications/{{ config('services.github.client_id') }}" target="_blank" rel="noopener noreferrer">we’ve been given access to them</a>.</p>
         </div>
         <div class="mt-8 text-center">
             <form action="{{ route('sync') }}" method="POST">

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -39,8 +39,8 @@
     <ul>
         <li><a href="{{ url('/') }}">Home</a></li>
         <li><a href="{{ url('https://status.miguelpiedrafita.com/components/58c0fca18c48eb4923fc46bf') }}"
-               target="_blank">Status Page</a></li>
-        <li><a href="{{ url('https://github.com/orgmanager/orgmanager') }}" target="_blank">GitHub</a></li>
+               target="_blank" rel="noopener noreferrer">Status Page</a></li>
+        <li><a href="{{ url('https://github.com/orgmanager/orgmanager') }}" target="_blank" rel="noopener noreferrer">GitHub</a></li>
     </ul>
 </footer>
 <script src="{{ url('js/404.min.js') }}"></script>

--- a/resources/views/errors/503.blade.php
+++ b/resources/views/errors/503.blade.php
@@ -25,11 +25,11 @@
         <nav>
             <ul>
                 <li>
-                    <a href="https://status.miguelpiedrafita.com/components/58c0fca18c48eb4923fc46bf" target="_blank"
+                    <a href="https://status.miguelpiedrafita.com/components/58c0fca18c48eb4923fc46bf" target="_blank" rel="noopener noreferrer"
                        id="status-page" class="light-btn text-intro opacity-0">OrgManager Status Page</a>
                 </li>
                 <li>
-                    <a href="https://github.com/orgmanager/orgmanager" target="_blank"
+                    <a href="https://github.com/orgmanager/orgmanager" target="_blank" rel="noopener noreferrer"
                        class="action-btn trigger text-intro opacity-0">GitHub</a>
                 </li>
             </ul>

--- a/resources/views/join.blade.php
+++ b/resources/views/join.blade.php
@@ -27,11 +27,11 @@
                     <img src="{{ $org->avatar }}" class="w-24 h-24 rounded-full mb-4">
                 </div>
 
-                <h1 class="font-bold text-2xl mb-2 text-center text-grey-darkest">Join <a class="no-underline text-inherit link-shadow link-transition" href="https://github.com/{{ $org->name }}" target="_blank">{{ $org->pretty_name or $org->name }}</a></h1>
+                <h1 class="font-bold text-2xl mb-2 text-center text-grey-darkest">Join <a class="no-underline text-inherit link-shadow link-transition" href="https://github.com/{{ $org->name }}" target="_blank" rel="noopener noreferrer">{{ $org->pretty_name or $org->name }}</a></h1>
 
                 @if (optional($org->team)->exists)
                     @if ($org->team->privacy == 'closed')
-                        <h1 class="text-sm mb-4 text-center text-grey-darker font-medium">You will also join the <a href="https://github.com/orgs/{{ $org->name }}/teams/{{ str_slug($org->team->name) }}" target="_blank" class="no-underline text-inherit link-shadow link-transition">{{ $org->team->name }}</a> team</h1>
+                        <h1 class="text-sm mb-4 text-center text-grey-darker font-medium">You will also join the <a href="https://github.com/orgs/{{ $org->name }}/teams/{{ str_slug($org->team->name) }}" target="_blank" rel="noopener noreferrer" class="no-underline text-inherit link-shadow link-transition">{{ $org->team->name }}</a> team</h1>
                     @else
                         <h1 class="text-sm mb-4 text-center text-grey-darker font-medium">You will also join the private {{ $org->team->name }} team</h1>
                     @endif

--- a/resources/views/landing.blade.php
+++ b/resources/views/landing.blade.php
@@ -21,7 +21,7 @@
                     <a href="{{ route('login') }}" class="flex items-center text-center no-underline bg-brand border-2 border-brand hover:bg-white text-white hover:text-brand font-bold py-3 px-6 self-stretch rounded-full">
                         Try it out!
                     </a>
-                    <a href="https://github.com/orgmanager/orgmanager" target="_blank" class="no-underline bg-black-light border-2 border-black-light hover:bg-white text-white hover:text-black-light font-bold py-3 px-6 self-stretch rounded-full">
+                    <a href="https://github.com/orgmanager/orgmanager" target="_blank" rel="noopener noreferrer" class="no-underline bg-black-light border-2 border-black-light hover:bg-white text-white hover:text-black-light font-bold py-3 px-6 self-stretch rounded-full">
                         <div class="flex items-center">
                             <svg class="w-6 h-6" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                                 <path d="M12 .3C5.4.3 0 5.7 0 12.3c0 5.3 3.4 9.8 8.2 11.4.6 0 .8-.3.8-.6v-2c-3.3.8-4-1.5-4-1.5-.6-1.4-1.4-1.8-1.4-1.8-1-.7 0-.7 0-.7 1.3 0 2 1.2 2 1.2 1 1.8 2.8 1.3 3.5 1 .2-.8.5-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-6 0-1.2.5-2.3 1.3-3-.2-.5-.6-1.7 0-3.3 0 0 1-.3 3.4 1.2 1-.3 2-.4 3-.4s2 .2 3 .5c2.3-1.5 3.3-1.2 3.3-1.2.6 1.6.2 2.8 0 3.2 1 .8 1.3 2 1.3 3.2 0 4.6-2.8 5.6-5.5 6 .6.3 1 1 1 2v3.4c0 .4 0 .8.8.7 4.8-1.6 8.2-6 8.2-11.4 0-6.6-5.4-12-12-12"/>
@@ -63,7 +63,7 @@
                 <p class="text-black-darker">Used by <span class="text-grey-darkest">{{ \App\User::count() }} users &amp; {{ \App\Org::count() }} orgs</span>, we have delivered <span class="text-grey-darkest">{{ \App\Org::sum('invitecount') }}</span> invites</p>
             </div>
             <div>
-                <a class="text-black-light no-underline" href="https://github.com/orgmanager/orgmanager" target="_blank">
+                <a class="text-black-light no-underline" href="https://github.com/orgmanager/orgmanager" target="_blank" rel="noopener noreferrer">
                     <svg class="w-6 h-6" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                         <path d="M12 .3C5.4.3 0 5.7 0 12.3c0 5.3 3.4 9.8 8.2 11.4.6 0 .8-.3.8-.6v-2c-3.3.8-4-1.5-4-1.5-.6-1.4-1.4-1.8-1.4-1.8-1-.7 0-.7 0-.7 1.3 0 2 1.2 2 1.2 1 1.8 2.8 1.3 3.5 1 .2-.8.5-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-6 0-1.2.5-2.3 1.3-3-.2-.5-.6-1.7 0-3.3 0 0 1-.3 3.4 1.2 1-.3 2-.4 3-.4s2 .2 3 .5c2.3-1.5 3.3-1.2 3.3-1.2.6 1.6.2 2.8 0 3.2 1 .8 1.3 2 1.3 3.2 0 4.6-2.8 5.6-5.5 6 .6.3 1 1 1 2v3.4c0 .4 0 .8.8.7 4.8-1.6 8.2-6 8.2-11.4 0-6.6-5.4-12-12-12"/>
                     </svg>

--- a/resources/views/orgs.blade.php
+++ b/resources/views/orgs.blade.php
@@ -37,7 +37,7 @@
                         </td>
                         <td class="flex items-center justify-center">
                             <p class="text-base text-grey mr-3">Invite Link</p>
-                            <a class="text-base text-brand-darker mr-6" href="{{ route('join', $org) }}" target="_blank">{{ route('join', $org) }}</a>
+                            <a class="text-base text-brand-darker mr-6" href="{{ route('join', $org) }}" target="_blank" rel="noopener noreferrer">{{ route('join', $org) }}</a>
                             <a href="{{ route('org', $org) }}" class="no-underline bg-brand hover:bg-brand-dark text-white font-bold py-3 px-4 rounded-full focus:outline-none">
                                 <div class="inline-block">
                                     <div class="flex items-center justify-center">

--- a/resources/views/orgs.blade.php
+++ b/resources/views/orgs.blade.php
@@ -66,7 +66,7 @@
                     <div class="py-1"><svg class="fill-current h-6 w-6 text-teal mr-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zm12.73-1.41A8 8 0 1 0 4.34 4.34a8 8 0 0 0 11.32 11.32zM9 11V9h2v6H9v-4zm0-6h2v2H9V5z"/></svg></div>
                     <div>
                     <p class="font-bold">Don't see the organization you need?</p>
-                    <p class="text-sm mt-1">Double check <a href="https://github.com/settings/connections/applications/{{ config('services.github.client_id') }}" class="no-underline text-inherit link-shadow link-transition" target="_blank">we have been given access to it</a> and then sync again.</p>
+                    <p class="text-sm mt-1">Double check <a href="https://github.com/settings/connections/applications/{{ config('services.github.client_id') }}" class="no-underline text-inherit link-shadow link-transition" target="_blank" rel="noopener noreferrer">we have been given access to it</a> and then sync again.</p>
                     </div>
                 </div>
             </div>

--- a/resources/views/settings.blade.php
+++ b/resources/views/settings.blade.php
@@ -67,7 +67,7 @@
                                               required="required">{{ old('message') }}</textarea>
                                     <small><a class="pull-left text-muted"
                                               href="https://guides.github.com/features/mastering-markdown/"
-                                              target="_blank"><i class="octicon octicon-markdown"></i>Styling with
+                                              target="_blank" rel="noopener noreferrer"><i class="octicon octicon-markdown"></i>Styling with
                                             Markdown is supported</a></small>
                                     <br>
                                     <br>
@@ -78,7 +78,7 @@
                         <br>
                         <div class="flash">
                             <p class="text-center">TIP: Want a pretty URL for your users? Share <a
-                                        href="{{ url('o/'.$org->name) }}" target="_blank">{{ url('o/'.$org->name) }}</a>
+                                        href="{{ url('o/'.$org->name) }}" target="_blank" rel="noopener noreferrer">{{ url('o/'.$org->name) }}</a>
                                 !</p>
                         </div>
                     </div>

--- a/resources/views/teams.blade.php
+++ b/resources/views/teams.blade.php
@@ -84,7 +84,7 @@
                         <br>
                         <div class="flash">
                             <p class="text-center">TIP: Want a pretty URL for your users? Share <a
-                                        href="{{ url('o/'.$org->name) }}" target="_blank">{{ url('o/'.$org->name) }}</a>
+                                        href="{{ url('o/'.$org->name) }}" target="_blank" rel="noopener noreferrer">{{ url('o/'.$org->name) }}</a>
                                 !</p>
                         </div>
                     </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If the links lack of `rel="noopener noreferrer"` attribute, third party site can change the URL of source tab using `window.opener.location.assign` and trick the user as if he is still in a trusted page and lead him to enter his secret information or credentials to this malicious copy.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
