### PR TITLE
fix breaking migration

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Schema;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -24,6 +25,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        Schema::defaultStringLength(191);
         Model::unguard();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added a schema default length in the app service provider file to allow for  users with MySQL version less than 5.7 to be able to run migrations.
## Related Issue
https://github.com/orgmanager/orgmanager/issues/510#issue-504247946

## Motivation and Context
Fixes a breaking migration, so that other users can work on the project

## How Has This Been Tested?

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/34219909/66429434-ef32be80-ea0f-11e9-96ae-adc67183e80e.png)

## Types of changes


## Checklist:

